### PR TITLE
Add transport mode to monitor output

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,15 @@ Output:
         "line": "85",
         "direction": "Striesen",
         "arrivalTimeRelative": 12,
-        "arrivalTime": "2015-12-13T19:23:18.374Z"
+        "arrivalTime": "2015-12-13T19:23:18.374Z",
+        "mode": "Stadtbus"
     },
     {
         "line": "85",
         "direction": "Löbtau Süd",
         "arrivalTimeRelative": 18,
-        "arrivalTime": "2015-12-13T19:23:24.374Z"
+        "arrivalTime": "2015-12-13T19:23:24.374Z",
+        "mode": "Stadtbus"
     }
 ]
 

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -30,7 +30,8 @@ var monitor = function monitor(stop, offset, amount, callback) {
                 line: transport[0],
                 direction: transport[1],
                 arrivalTimeRelative: arrivalTimeRelative,
-                arrivalTime: new Date(now.getTime() + 1000 * arrivalTimeRelative)
+                arrivalTime: new Date(now.getTime() + 1000 * arrivalTimeRelative),
+                mode: utils.parseMode(transport[0])
             };
         }).nodeify(callback);
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -61,6 +61,33 @@ utils.parsePin = function parsePin(dataAsString, pinType) {
     };
 };
 
+utils.parseMode = function parseMode(id) {
+    if (parseInt(id) != undefined) {
+        var intID = parseInt(id);
+        if (between(intID, 0, 59)) return 'Straßenbahn';
+        if (between(intID, 60, 99)) return 'Stadtbus';
+        if (between(intID, 100, 1000)) return 'Regionalbus';
+    }
+    if (id === 'SWB') return 'Seil-/Schwebebahn';
+    if (matches(id, /^E\d/)) return 'Straßenbahn';
+    if (matches(id, /^E\d\d/)) return 'Stadtbus';
+    if (matches(id, /^F/)) return 'Fähre';
+    if (matches(id, /(^RE|^IC|^TL|^RB)/)) return 'Zug';
+    if (matches(id, /^S/)) return 'S-Bahn';
+    if (matches(id, /alita/)) return 'Rufbus';
+
+    return '';
+}
+
+function between(val, min, max) {
+    return val >= min && val <= max;
+}
+
+function matches(val, regex) {
+    var matches = val.match(regex);
+    return matches != undefined && matches.length > 0;
+}
+
 function parseConnections(data) {
     if (!data) return [];
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -69,8 +69,8 @@ utils.parseMode = function parseMode(id) {
         if (between(intID, 100, 1000)) return 'Regionalbus';
     }
     if (id === 'SWB') return 'Seil-/Schwebebahn';
+    if (matches(id, /^E\d\d/)) return 'Stadtbus'; // FIXME: This is probably not always correct^^
     if (matches(id, /^E\d/)) return 'Straßenbahn';
-    if (matches(id, /^E\d\d/)) return 'Stadtbus';
     if (matches(id, /^F/)) return 'Fähre';
     if (matches(id, /(^RE|^IC|^TL|^RB)/)) return 'Zug';
     if (matches(id, /^S/)) return 'S-Bahn';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -69,10 +69,16 @@ utils.parseMode = function parseMode(id) {
         if (between(intID, 100, 1000)) return 'Regionalbus';
     }
     if (id === 'SWB') return 'Seil-/Schwebebahn';
-    if (matches(id, /^E\d\d/)) return 'Stadtbus'; // FIXME: This is probably not always correct^^
-    if (matches(id, /^E\d/)) return 'Straßenbahn';
+
+    if (matches(id, /^E\d+/)) {
+        var match = id.match(/^E(\d+)/);
+        if (match[1] <= 59) return 'Straßenbahn';
+        else return 'Stadtbus';
+    }
+
+    if (matches(id, /^\D$|^\D\/\D$/)) return 'Regionalbus';
     if (matches(id, /^F/)) return 'Fähre';
-    if (matches(id, /(^RE|^IC|^TL|^RB)/)) return 'Zug';
+    if (matches(id, /^RE|^IC|^TL|^RB|^SB|^SE|^U\d/)) return 'Zug';
     if (matches(id, /^S/)) return 'S-Bahn';
     if (matches(id, /alita/)) return 'Rufbus';
 

--- a/test/test.js
+++ b/test/test.js
@@ -490,6 +490,7 @@ describe('internal utils', function () {
             assert.equal(utils.parseMode('11'), 'Straßenbahn');
             assert.equal(utils.parseMode('59'), 'Straßenbahn');
             assert.equal(utils.parseMode('E8'), 'Straßenbahn');
+            assert.equal(utils.parseMode('E11'), 'Straßenbahn');
             assert.notEqual(utils.parseMode('85'), 'Straßenbahn');
             done();
         });
@@ -507,6 +508,10 @@ describe('internal utils', function () {
             assert.equal(utils.parseMode('366'), 'Regionalbus');
             assert.equal(utils.parseMode('999'), 'Regionalbus');
             assert.equal(utils.parseMode('100'), 'Regionalbus');
+            assert.equal(utils.parseMode('A'), 'Regionalbus');
+            assert.equal(utils.parseMode('Z'), 'Regionalbus');
+            assert.equal(utils.parseMode('G/L'), 'Regionalbus');
+            assert.equal(utils.parseMode('H/S'), 'Regionalbus');
             assert.notEqual(utils.parseMode('85'), 'Regionalbus');
             done();
         });
@@ -519,6 +524,7 @@ describe('internal utils', function () {
 
         it('should identify correct values as `Fähre`', function (done) {
             assert.equal(utils.parseMode('F7'), 'Fähre');
+            assert.equal(utils.parseMode('F14'), 'Fähre');
             assert.notEqual(utils.parseMode('85'), 'Fähre');
             done();
         });
@@ -528,11 +534,15 @@ describe('internal utils', function () {
             assert.equal(utils.parseMode('IC 1717'), 'Zug');
             assert.equal(utils.parseMode('RB 1717'), 'Zug');
             assert.equal(utils.parseMode('TLX 1717'), 'Zug');
+            assert.equal(utils.parseMode('SB33'), 'Zug'); // Sächsische Städtebahn
+            assert.equal(utils.parseMode('SE19'), 'Zug'); // Wintersport Express o.O
+            assert.equal(utils.parseMode('U28'), 'Zug'); // Bad Schandau -> Děčín
             assert.notEqual(utils.parseMode('S 1717'), 'Zug');
             done();
         });
 
         it('should identify correct values as `S-Bahn`', function (done) {
+            assert.equal(utils.parseMode('S3'), 'S-Bahn');
             assert.equal(utils.parseMode('S 1717'), 'S-Bahn');
             assert.notEqual(utils.parseMode('IC 1717'), 'S-Bahn');
             assert.notEqual(utils.parseMode('RB 1717'), 'S-Bahn');
@@ -541,8 +551,14 @@ describe('internal utils', function () {
 
         it('should identify correct values as `Rufbus`', function (done) {
             assert.equal(utils.parseMode('alita'), 'Rufbus');
+            assert.equal(utils.parseMode('alita 95'), 'Rufbus');
             assert.notEqual(utils.parseMode('85'), 'Rufbus');
             done();
         });
+
+        it('should fail with `""`', function (done) {
+            assert.equal(utils.parseMode('Lorem Ipsum'), '');
+            done();
+        })
     });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -480,3 +480,69 @@ describe('dvb.coords for id from dvb.pins', function () {
         });
     });
 });
+
+describe('internal utils', function () {
+    var utils = require('../lib/utils');
+
+    describe('parseMode', function () {
+        it('should identify correct values as `Straßenbahn`', function (done) {
+            assert.equal(utils.parseMode('3'), 'Straßenbahn');
+            assert.equal(utils.parseMode('11'), 'Straßenbahn');
+            assert.equal(utils.parseMode('59'), 'Straßenbahn');
+            assert.equal(utils.parseMode('E8'), 'Straßenbahn');
+            assert.notEqual(utils.parseMode('85'), 'Straßenbahn');
+            done();
+        });
+
+        it('should identify correct values as `Stadtbus`', function (done) {
+            assert.equal(utils.parseMode('85'), 'Stadtbus');
+            assert.equal(utils.parseMode('99'), 'Stadtbus');
+            assert.equal(utils.parseMode('60'), 'Stadtbus');
+            assert.equal(utils.parseMode('E75'), 'Stadtbus');
+            assert.notEqual(utils.parseMode('100'), 'Stadtbus');
+            done();
+        });
+
+        it('should identify correct values as `Regionalbus`', function (done) {
+            assert.equal(utils.parseMode('366'), 'Regionalbus');
+            assert.equal(utils.parseMode('999'), 'Regionalbus');
+            assert.equal(utils.parseMode('100'), 'Regionalbus');
+            assert.notEqual(utils.parseMode('85'), 'Regionalbus');
+            done();
+        });
+
+        it('should identify correct values as `Seil-/Schwebebahn`', function (done) {
+            assert.equal(utils.parseMode('SWB'), 'Seil-/Schwebebahn');
+            assert.notEqual(utils.parseMode('85'), 'Seil-/Schwebebahn');
+            done();
+        });
+
+        it('should identify correct values as `Fähre`', function (done) {
+            assert.equal(utils.parseMode('F7'), 'Fähre');
+            assert.notEqual(utils.parseMode('85'), 'Fähre');
+            done();
+        });
+
+        it('should identify correct values as `Zug`', function (done) {
+            assert.equal(utils.parseMode('ICE 1717'), 'Zug');
+            assert.equal(utils.parseMode('IC 1717'), 'Zug');
+            assert.equal(utils.parseMode('RB 1717'), 'Zug');
+            assert.equal(utils.parseMode('TLX 1717'), 'Zug');
+            assert.notEqual(utils.parseMode('S 1717'), 'Zug');
+            done();
+        });
+
+        it('should identify correct values as `S-Bahn`', function (done) {
+            assert.equal(utils.parseMode('S 1717'), 'S-Bahn');
+            assert.notEqual(utils.parseMode('IC 1717'), 'S-Bahn');
+            assert.notEqual(utils.parseMode('RB 1717'), 'S-Bahn');
+            done();
+        });
+
+        it('should identify correct values as `Rufbus`', function (done) {
+            assert.equal(utils.parseMode('alita'), 'Rufbus');
+            assert.notEqual(utils.parseMode('85'), 'Rufbus');
+            done();
+        });
+    });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -39,6 +39,7 @@ describe('dvb.monitor', function () {
             assert(transport.direction);
             assert.strictEqual('number', typeof transport.arrivalTimeRelative);
             assert.strictEqual('object', typeof transport.arrivalTime);
+            assert.strictEqual('string', typeof transport.mode);
         }
 
         it('should return an array with elements', function (done) {
@@ -53,7 +54,7 @@ describe('dvb.monitor', function () {
                 });
         });
 
-        it('should contain all four fields', function (done) {
+        it('should contain all five fields', function (done) {
             dvb.monitor('postplatz', 0, 5)
                 .then(function (data) {
                     data.forEach(assertTransport);


### PR DESCRIPTION
Calls to `.monitor` should now include a transport mode (e.g. `Bus`, `Straßenbahn`, etc.) as well.