### PR TITLE
Call coordinate conversion with explicit data type

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -38,7 +38,7 @@ function depatureMonitor(stopid, offset, amount) {
 
                     return {
                         line: d.LineName,
-                        direction: d.Direction,
+                        direction: d.Direction.trim(),
                         platform: d.Platform ? { name: d.Platform.Name, type: d.Platform.Type } : undefined,
                         arrivalTime: arrivalTime,
                         arrivalTimeRelative: Math.round((arrivalTime - now) / 1000 / 60),

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,11 +6,11 @@ var proj4 = require('proj4');
 proj4.defs("GK4", "+proj=tmerc +lat_0=0 +lon_0=12 +k=1 +x_0=4500000 +y_0=0 +ellps=bessel +datum=potsdam +units=m");
 
 utils.WGS84toGK4 = function WGS84toGK4(lat, lng) {
-    return proj4("WGS84", "GK4", [lng, lat]).map(Math.round);
+    return proj4("WGS84", "GK4", [Number(lng), Number(lat)]).map(Math.round);
 };
 
 utils.GK4toWGS84 = function GK4toWGS84(lat, lng) {
-    return proj4("GK4", "WGS84", [lng, lat]).reverse();
+    return proj4("GK4", "WGS84", [Number(lng), Number(lat)]).reverse();
 };
 
 utils.stripSpaces = function stripSpaces(s) {


### PR DESCRIPTION
The conversion is done by calling function in 'proj4'. This function complains about arguments not being finite, when called without explicit cast to Number().
After applying this fix all tests run OK.