### PR TITLE
Increase timeout for trip api requests

### DIFF
--- a/src/route.ts
+++ b/src/route.ts
@@ -26,7 +26,7 @@ export function route(originID: string, destinationID: string,
       shorttermchanges: true,
       time: time.toISOString(),
     },
-    timeout: 2000,
+    timeout: 4500,
   };
 
   return axios(options)


### PR DESCRIPTION
For some trip requests, the current timeout setting of 2000ms seems not to be sufficient. For instance, the vvo API takes longer for certain trip / route requests that expand outside of the Dresden area. 

I have added a sample below where I'm getting `timeout exceeded` errors:

```ts
import { route } from "../route";

const testRoute = async () => {

  // Dresden, Elbepark -> Radberg, Am Sandberg
  try {
    await route("33000588", "33006732");
  } catch (error) {
      console.log(error.stack)
  }
};

testRoute();
```

```shell
Error: timeout of 2000ms exceeded
    at createError (/Users/ben/projects/dvbjs/node_modules/axios/lib/core/createError.js:16:15)
    at Timeout.handleRequestTimeout [as _onTimeout] (/Users/ben/projects/dvbjs/node_modules/axios/lib/adapters/http.js:216:16)
    at ontimeout (timers.js:427:11)
    at tryOnTimeout (timers.js:289:5)
    at listOnTimeout (timers.js:252:5)
    at Timer.processTimers (timers.js:212:10)
``` 

My suggestion is to increase the timeout setting for API `trip` requests.