### PR TITLE
Added the StopID to ILocation

### DIFF
--- a/packages/dvbjs/src/interfaces.ts
+++ b/packages/dvbjs/src/interfaces.ts
@@ -95,6 +95,7 @@ export interface ILocation {
   name: string;
   city: string;
   coords: coord;
+  id: string;
 }
 
 export interface IStop extends ILocation {

--- a/packages/dvbjs/src/route.ts
+++ b/packages/dvbjs/src/route.ts
@@ -49,11 +49,13 @@ export function route(
           origin = {
             name: firstTrip.departure.name,
             city: firstTrip.departure.city,
+            id: firstTrip.departure.id,
             coords: firstTrip.departure.coords,
           };
           destination = {
             name: firstTrip.arrival.name,
             city: firstTrip.arrival.city,
+            id: firstTrip.arrival.id,
             coords: firstTrip.arrival.coords,
           };
         }

--- a/packages/dvbjs/src/utils.ts
+++ b/packages/dvbjs/src/utils.ts
@@ -294,6 +294,7 @@ function extractStop(stop: any): IStop {
   return {
     name: stop.Name.trim(),
     city: stop.Place,
+    id: stop.DataId,
     type: stop.Type,
     platform: parsePlatform(stop.Platform),
     coords: GK4toWGS84(stop.Longitude, stop.Latitude) || [0, 0],
@@ -317,6 +318,7 @@ function extractNode(node: any, mapData: any): INode {
     departure = {
       name: firstStop.name,
       city: firstStop.city,
+      id: firstStop.id,
       platform: firstStop.platform,
       time: firstStop.departure,
       coords: firstStop.coords,
@@ -326,6 +328,7 @@ function extractNode(node: any, mapData: any): INode {
     arrival = {
       name: lastStop.name,
       city: lastStop.city,
+      id: lastStop.id,
       platform: lastStop.platform,
       time: lastStop.arrival,
       coords: lastStop.coords,


### PR DESCRIPTION
... in order to directly reuse a stop from any route.

Whenever you want to use a specific stop, you need its ID. It's a common use case to navigate to the stop monitoring view based any stop shown in the currently active route. Without the stop's id you'd have to perform another search for the stop id based on its name. This is now unnecessary.