### PR TITLE
Fix missing/removed icon Urls

### DIFF
--- a/packages/dvbjs/src/utils.ts
+++ b/packages/dvbjs/src/utils.ts
@@ -187,47 +187,47 @@ export const MODES = {
   Footpath: {
     title: "Fussweg",
     name: "Footpath",
-    iconUrl: "https://m.dvb.de/img/walk.svg",
+    iconUrl: "https://www.dvb.de/assets/img/trans-icon/walk.svg",
   },
   StairsUp: {
     title: "Treppe aufwärts",
     name: "StairsUp",
-    iconUrl: "https://m.dvb.de/img/stairs-up.svg",
+    iconUrl: "https://www.dvb.de/assets/img/trans-icon/stairs-up.svg",
   },
   StairsDown: {
     title: "Treppe abwärts",
     name: "StairsDown",
-    iconUrl: "https://m.dvb.de/img/stairs-down.svg",
+    iconUrl: "https://www.dvb.de/assets/img/trans-icon/stairs-down.svg",
   },
   EscalatorUp: {
     title: "Rolltreppe aufwärts",
     name: "EscalatorUp",
-    iconUrl: "https://m.dvb.de/img/escalator-up.svg",
+    iconUrl: "https://www.dvb.de/assets/img/trans-icon/escalator-up.svg",
   },
   EscalatorDown: {
     title: "Rolltreppe abwärts",
     name: "EscalatorDown",
-    iconUrl: "https://m.dvb.de/img/escalator-down.svg",
+    iconUrl: "https://www.dvb.de/assets/img/trans-icon/escalator-down.svg",
   },
   ElevatorUp: {
     title: "Fahrstuhl aufwärts",
     name: "ElevatorUp",
-    iconUrl: "https://m.dvb.de/img/elevator-up.svg",
+    iconUrl: "https://www.dvb.de/assets/img/trans-icon/elevator-up.svg",
   },
   ElevatorDown: {
     title: "Fahrstuhl abwärts",
     name: "ElevatorDown",
-    iconUrl: "https://m.dvb.de/img/elevator-down.svg",
+    iconUrl: "https://www.dvb.de/assets/img/trans-icon/elevator-down.svg",
   },
   StayForConnection: {
     title: "gesicherter Anschluss",
     name: "StayForConnection",
-    iconUrl: "https://m.dvb.de/img/sit.svg",
+    iconUrl: "https://www.dvb.de/assets/img/trans-icon/sit.svg",
   },
   PlusBus: {
     title: "PlusBus",
     name: "PlusBus",
-    iconUrl: "https://m.dvb.de/img/mot_icons/plusBus.svg",
+    iconUrl: "https://www.dvb.de/assets/img/trans-icon/transport-plusbus.svg",
   },
 };
 


### PR DESCRIPTION
In my usage of in the dvbjs specified icon urls a few weren't found since a few days. It seems like the DVB removed them from the mobile website and now only stores icons on www.dvb.de. I updated all broken icon links with this pr.